### PR TITLE
Update auf Guzzle 6, Support für PHP 5.4 entfernt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@ desktop.ini
 .idea
 
 vendor/*
-tests/behat/bin/behat
-tests/behat/bin/phpunit
+tests/behat/bin/*
 tests/behat/behat-prod.yml
 composer.lock
 composer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-- 5.4
 - 5.5
 - 5.6
 - 7

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
     "require": {
-        "php": ">=5.4",
-        "behat/behat": "3.0.*",
-        "guzzlehttp/guzzle": "4.*",
-        "phpunit/phpunit": "4.*"
+        "php": ">=5.5",
+        "behat/behat": "~3.0",
+        "guzzlehttp/guzzle": "~6.0",
+        "phpunit/phpunit": "~4.0"
     },
     "config": {
         "bin-dir": "tests/behat/bin/"


### PR DESCRIPTION
Das bisher verwendete Guzzle 4 wird nicht mehr maintained. Dieser PR ist ein Update auf Guzzle 6. Weil Guzzle 6 aber mindestens PHP 5.5 benötigt, habe ich den Support für PHP 5.4 entfernt. Bei der Planung der API ist die PHP-Version aber nicht so relevant.