### PR TITLE
Neue Resource Post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+
+- new resource `Post` with new endpoint `/posts/<post_id>`
+- new scope `post:read` to view the posts of a user and his friends
+- new post author endpoints `/posts/<post_id>/author` and `/posts/<post_id>/relationships/author`
+- new post parent endpoints `/posts/<post_id>/parent` and `/posts/<post_id>/relationships/parent`
+- new endpoint `users/<user_id>/posts` to list the posts of a user
+
 ### Changed
 
 - Update LICENSE to GPL v3

--- a/apiary.apib
+++ b/apiary.apib
@@ -24,6 +24,39 @@ Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.ver
 
 Alle Informationen zur Authentication findest du hier: http://developer.youthweb.net/api_general_oauth2.html
 
+# Group Posts
+
+## Post [/posts/{post_id}]
+
+Ein Post Objekt hat die folgenden Attribute
+
++ type
++ id - The Post-ID
++ attributes - An object of attributes.
+
++ Parameters
+    + post_id: d5a5a2c3-041b-4985-907c-74a2131efc98 (required, string) - ID of the post as a uuid string
+
+### Daten zu einem Post abrufen [GET]
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+            Authorization: Bearer valid_JWT
+
++ Response 200 (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
+    + Attributes
+
+        + data (Post Base)
+        + included (array)
+            + (User Base)
+
 # Group Stats
 
 Für die Statistiken ist keine Autorisierung nötig.
@@ -149,27 +182,7 @@ Ein User Objekt hat die folgenden Attribute
 
     + Attributes
 
-        + data (object)
-            + type: `users` (string)
-            + id: `123456` (string) - Die User-ID
-            + attributes (object)
-                + username: `JohnSmith` (string) - Der Username
-                + `first_name`: `John` (string, nullable) - Der Vorname
-                + `last_name`: `Smith` (string, nullable) - Der Nachname
-                + email: `john_smith@example.org` (string, nullable) - Die E-Mail Adresse
-                + birthday: `1988-03-05` (string, nullable) - Geburtstag im Format YYYY-MM-DD
-                + `created_at`: `2006-01-01T21:00:00+01:00` (string) - Zeitpunkt der Registrierung als ISO-8601
-                + `last_login`: `2016-01-01T22:00:00+02:00` (string) - Zeitpunkt des letzten Logins als ISO-8601
-                + zip: `12345` (string, nullable) - Die Postleitzahl
-                + city: `Jamestown` (string, nullable) - Die Stadt
-                + `description_jesus`: `Lorem ipsum dolor sit amet` (string, nullable) - "Was ich von Jesus halte"
-                + `description_job`: `Lorem ipsum dolor sit amet` (string, nullable) - Der Beruf
-                + `description_hobbies`: `Lorem ipsum dolor sit amet` (string, nullable) - Die Hobbies
-                + `description_motto`: `Lorem ipsum dolor sit amet` (string, nullable) - Das Lebensmotto
-                + `picture_thumb_url`: `https://youthweb.net/img/steckbriefe/default_pic_m.jpg` (string) - Url zum Profilbild (Thumbnail)
-                + `picture_url`: `https://youthweb.net/img/steckbriefe/default_pic_m.jpg` (string) - Url zum Profilbild (Vollbild)
-            + links (object)
-                + self: `/users/123456` (string) - Der Link zu dieser Resource
+        + data (User Base)
 
 ## Me [/me]
 
@@ -191,27 +204,7 @@ Fragt die Userdaten des autorisierten Users ab. Dies ist ein Shortcut für /user
 
     + Attributes
 
-        + data (object)
-            + type: `users` (string)
-            + id: `123456` (string) - Die User-ID
-            + attributes (object)
-                + username: `JohnSmith` (string) - Der Username
-                + `first_name`: `John` (string, nullable) - Der Vorname
-                + `last_name`: `Smith` (string, nullable) - Der Nachname
-                + email: `john_smith@example.org` (string, nullable) - Die E-Mail Adresse
-                + birthday: `1988-03-05` (string, nullable) - Geburtstag im Format YYYY-MM-DD
-                + `created_at`: `2006-01-01T21:00:00+01:00` (string) - Zeitpunkt der Registrierung als ISO-8601
-                + `last_login`: `2016-01-01T22:00:00+02:00` (string) - Zeitpunkt des letzten Logins als ISO-8601
-                + zip: `12345` (string, nullable) - Die Postleitzahl
-                + city: `Jamestown` (string, nullable) - Die Stadt
-                + `description_jesus`: `Lorem ipsum dolor sit amet` (string, nullable) - "Was ich von Jesus halte"
-                + `description_job`: `Lorem ipsum dolor sit amet` (string, nullable) - Der Beruf
-                + `description_hobbies`: `Lorem ipsum dolor sit amet` (string, nullable) - Die Hobbies
-                + `description_motto`: `Lorem ipsum dolor sit amet` (string, nullable) - Das Lebensmotto
-                + `picture_thumb_url`: `https://youthweb.net/img/steckbriefe/default_pic_m.jpg` (string) - Url zum Profilbild (Thumbnail)
-                + `picture_url`: `https://youthweb.net/img/steckbriefe/default_pic_m.jpg` (string) - Url zum Profilbild (Vollbild)
-            + links (object)
-                + self: `/users/123456` (string) - Der Link zu dieser Resource
+        + data (User Base)
 
 # Group Auth
 
@@ -245,3 +238,59 @@ Dieser Endpoint ist veraltet und wird gegen OAuth2 ausgetauscht. Siehe http://de
             + `token_type`: `Bearer` (string)
             + `warnings` (array)
                 + `The resource /auth/token is deprecated and will replaced with OAuth2 authorization. Please see http://developer.youthweb.net/api_general_oauth2.html` (string)
+
+# Data Structures
+
+## Post Base (object)
+
++ type: `posts` (string)
++ id: `d5a5a2c3-041b-4985-907c-74a2131efc98` (string) - Die Post-ID
++ attributes (object)
+    + `uuid`: `d5a5a2c3-041b-4985-907c-74a2131efc98` (string) - Die Post-ID als UUID
+    + `title`: `The post title` (string) - Der Title, kann auch leer sein
+    + `content`: `Lorem ipsum dolor sit amet, sed libris elaboraret eu.` (string) - Der Post-Inhalt
+    + `view_allowed_for`: `users` (string) - Wer kann diesen Post sehen? (`all`, `users`, `friends` oder `authors`)
+    + `comments_allowed`: true (boolean) - Kann dieser Post kommentiert werden?
+    + `comments_count`: 15 (number) - Die Gesamtanzahl der Kommentare zu diesem Post
+    + `created_at`: `2017-01-01T18:51:02+01:00` (string) - Zeitpunkt der Erstellung als ISO-8601
+    + `updated_at`: `2017-01-03T14:17:11+01:00` (string) - Zeitpunkt der letzten Änderung als ISO-8601
++ `relationships` (object)
+    + `author` (object) - Der Autor des Posts
+        + data (object)
+            + type: `users` (string)
+            + id: `123456` (string)
+        + links (object)
+            + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/author` (string)
+            + related: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/author` (string)
+    + parent (object) - Das Elternobjekt, dem dieser Post zugeordnet ist
+        + data (object)
+            + type: `users` (string)
+            + id: `123456` (string)
+        + links (object)
+            + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/parent` (string)
+            + related: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/parent` (string)
++ links (object)
+    + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98` (string) - Der Link zu dieser Resource
+
+## User Base (object)
+
++ type: `users` (string)
++ id: `123456` (string) - Die User-ID
++ attributes (object)
+    + username: `JohnSmith` (string) - Der Username
+    + `first_name`: `John` (string, nullable) - Der Vorname
+    + `last_name`: `Smith` (string, nullable) - Der Nachname
+    + email: `john_smith@example.org` (string, nullable) - Die E-Mail Adresse
+    + birthday: `1988-03-05` (string, nullable) - Geburtstag im Format YYYY-MM-DD
+    + `created_at`: `2006-01-01T21:00:00+01:00` (string) - Zeitpunkt der Registrierung als ISO-8601
+    + `last_login`: `2016-01-01T22:00:00+02:00` (string) - Zeitpunkt des letzten Logins als ISO-8601
+    + zip: `12345` (string, nullable) - Die Postleitzahl
+    + city: `Jamestown` (string, nullable) - Die Stadt
+    + `description_jesus`: `Lorem ipsum dolor sit amet` (string, nullable) - "Was ich von Jesus halte"
+    + `description_job`: `Lorem ipsum dolor sit amet` (string, nullable) - Der Beruf
+    + `description_hobbies`: `Lorem ipsum dolor sit amet` (string, nullable) - Die Hobbies
+    + `description_motto`: `Lorem ipsum dolor sit amet` (string, nullable) - Das Lebensmotto
+    + `picture_thumb_url`: `https://youthweb.net/img/steckbriefe/default_pic_m.jpg` (string) - Url zum Profilbild (Thumbnail)
+    + `picture_url`: `https://youthweb.net/img/steckbriefe/default_pic_m.jpg` (string) - Url zum Profilbild (Vollbild)
++ links (object)
+    + self: `/users/123456` (string) - Der Link zu dieser Resource

--- a/apiary.apib
+++ b/apiary.apib
@@ -379,12 +379,12 @@ Dieser Endpoint ist veraltet und wird gegen OAuth2 ausgetauscht. Siehe http://de
     + `created_at`: `2017-01-01T18:51:02+01:00` (string) - Zeitpunkt der Erstellung als ISO-8601
     + `updated_at`: `2017-01-03T14:17:11+01:00` (string, nullable) - Zeitpunkt der letzten Änderung als ISO-8601
 + `relationships` (object)
-    + `author` (object) - Der Autor des Posts
+    + `author` (object, nullable) - Der Autor des Posts
         + data (User Linkage)
         + links (object)
             + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/author` (string)
             + related: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/author` (string)
-    + parent (object) - Das Elternobjekt, dem dieser Post zugeordnet ist
+    + parent (object, nullable) - Das Elternobjekt, dem dieser Post zugeordnet ist
         + data (User Linkage)
         + links (object)
             + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/parent` (string)

--- a/apiary.apib
+++ b/apiary.apib
@@ -85,7 +85,7 @@ Ein Post Objekt hat die folgenden Attribute
 + Parameters
     + post_id: d5a5a2c3-041b-4985-907c-74a2131efc98 (required, string) - ID of the post as a uuid string
 
-### Autor Relationship zu einem Post abrufen [GET]
+### Author Relationship zu einem Post abrufen [GET]
 + Request (application/vnd.api+json)
 
     + Headers
@@ -105,6 +105,55 @@ Ein Post Objekt hat die folgenden Attribute
         + links (object)
             + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/author` (string)
             + related: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/author` (string)
+
+## Post Parent [/posts/{post_id}/parent]
+
++ Parameters
+    + post_id: d5a5a2c3-041b-4985-907c-74a2131efc98 (required, string) - ID of the post as a uuid string
+
+### Elternobjekt zu einem Post abrufen [GET]
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+            Authorization: Bearer valid_JWT
+
++ Response 200 (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
+    + Attributes
+
+        + data (User Base)
+
+## Post Parent Relationship [/posts/{post_id}/relationships/parent]
+
++ Parameters
+    + post_id: d5a5a2c3-041b-4985-907c-74a2131efc98 (required, string) - ID of the post as a uuid string
+
+### Parent Relationship zu einem Post abrufen [GET]
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+            Authorization: Bearer valid_JWT
+
++ Response 200 (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
+    + Attributes
+
+        + data (User Linkage)
+        + links (object)
+            + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/parent` (string)
+            + related: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/parent` (string)
 
 # Group Stats
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -371,14 +371,13 @@ Dieser Endpoint ist veraltet und wird gegen OAuth2 ausgetauscht. Siehe http://de
 + type: `posts` (string)
 + id: `d5a5a2c3-041b-4985-907c-74a2131efc98` (string) - Die Post-ID
 + attributes (object)
-    + `uuid`: `d5a5a2c3-041b-4985-907c-74a2131efc98` (string) - Die Post-ID als UUID
     + `title`: `The post title` (string) - Der Title, kann auch leer sein
     + `content`: `Lorem ipsum dolor sit amet, sed libris elaboraret eu.` (string) - Der Post-Inhalt
     + `view_allowed_for`: `users` (string) - Wer kann diesen Post sehen? (`all`, `users`, `friends` oder `authors`)
     + `comments_allowed`: true (boolean) - Kann dieser Post kommentiert werden?
     + `comments_count`: 15 (number) - Die Gesamtanzahl der Kommentare zu diesem Post
     + `created_at`: `2017-01-01T18:51:02+01:00` (string) - Zeitpunkt der Erstellung als ISO-8601
-    + `updated_at`: `2017-01-03T14:17:11+01:00` (string) - Zeitpunkt der letzten Änderung als ISO-8601
+    + `updated_at`: `2017-01-03T14:17:11+01:00` (string, nullable) - Zeitpunkt der letzten Änderung als ISO-8601
 + `relationships` (object)
     + `author` (object) - Der Autor des Posts
         + data (User Linkage)

--- a/apiary.apib
+++ b/apiary.apib
@@ -184,6 +184,33 @@ Ein User Objekt hat die folgenden Attribute
 
         + data (User Base)
 
+## Posts of an User [/users/{user_id}/posts]
+
+Liefert die Posts von der Pinnwand eines Users
+
++ Parameters
+    + user_id: 123456 (required, number) - ID of the user
+
+### Posts zu einem User abrufen [GET]
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+            Authorization: Bearer valid_JWT
+
++ Response 200 (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
+    + Attributes
+
+        + data (array[Post Base])
+        + included (array)
+            + (User Base)
+
 ## Me [/me]
 
 Fragt die Userdaten des autorisierten Users ab. Dies ist ein Shortcut für /users/{user_id}, wenn die User-ID des autorisierten Users nicht bekannt ist.

--- a/apiary.apib
+++ b/apiary.apib
@@ -57,6 +57,55 @@ Ein Post Objekt hat die folgenden Attribute
         + included (array)
             + (User Base)
 
+## Post Author [/posts/{post_id}/author]
+
++ Parameters
+    + post_id: d5a5a2c3-041b-4985-907c-74a2131efc98 (required, string) - ID of the post as a uuid string
+
+### Author zu einem Post abrufen [GET]
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+            Authorization: Bearer valid_JWT
+
++ Response 200 (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
+    + Attributes
+
+        + data (User Base)
+
+## Post Author Relationship [/posts/{post_id}/relationships/author]
+
++ Parameters
+    + post_id: d5a5a2c3-041b-4985-907c-74a2131efc98 (required, string) - ID of the post as a uuid string
+
+### Autor Relationship zu einem Post abrufen [GET]
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+            Authorization: Bearer valid_JWT
+
++ Response 200 (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
+    + Attributes
+
+        + data (User Linkage)
+        + links (object)
+            + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/author` (string)
+            + related: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/author` (string)
+
 # Group Stats
 
 Für die Statistiken ist keine Autorisierung nötig.
@@ -283,16 +332,12 @@ Dieser Endpoint ist veraltet und wird gegen OAuth2 ausgetauscht. Siehe http://de
     + `updated_at`: `2017-01-03T14:17:11+01:00` (string) - Zeitpunkt der letzten Änderung als ISO-8601
 + `relationships` (object)
     + `author` (object) - Der Autor des Posts
-        + data (object)
-            + type: `users` (string)
-            + id: `123456` (string)
+        + data (User Linkage)
         + links (object)
             + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/author` (string)
             + related: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/author` (string)
     + parent (object) - Das Elternobjekt, dem dieser Post zugeordnet ist
-        + data (object)
-            + type: `users` (string)
-            + id: `123456` (string)
+        + data (User Linkage)
         + links (object)
             + self: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/parent` (string)
             + related: `/posts/d5a5a2c3-041b-4985-907c-74a2131efc98/parent` (string)
@@ -321,3 +366,8 @@ Dieser Endpoint ist veraltet und wird gegen OAuth2 ausgetauscht. Siehe http://de
     + `picture_url`: `https://youthweb.net/img/steckbriefe/default_pic_m.jpg` (string) - Url zum Profilbild (Vollbild)
 + links (object)
     + self: `/users/123456` (string) - Der Link zu dieser Resource
+
+## User Linkage (object)
+
++ type: `users` (string)
++ id: `123456` (string) - Die User-ID

--- a/docs/_data/sidebars/api_sidebar.yml
+++ b/docs/_data/sidebars/api_sidebar.yml
@@ -43,6 +43,10 @@ entries:
       url: /api_endpoint_me.html
       output: web
 
+    - title: Posts
+      url: /api_endpoint_posts.html
+      output: web
+
     - title: Stats
       url: /api_endpoint_stats.html
       output: web

--- a/docs/pages/api/api_endpoint_index.md
+++ b/docs/pages/api/api_endpoint_index.md
@@ -18,6 +18,7 @@ folder: api
 | Endpoint                              | Beschreibung                                                                       |
 |---------------------------------------|------------------------------------------------------------------------------------|
 | [/me][api_endpoint_me]                | Liefert die User-Resource des autorisierten User                                   |
+| [/posts][api_endpoint_posts]          | Liefert eine Post-Resource                                                         |
 | [/stats][api_endpoint_stats]          | Liefert eine Statisik-Resource                                                     |
 | [/users][api_endpoint_users]          | Liefert eine User-Resource                                                         |
 

--- a/docs/pages/api/api_endpoint_posts.md
+++ b/docs/pages/api/api_endpoint_posts.md
@@ -1,0 +1,100 @@
+---
+title: Posts/{post_id}
+keywords: Youthweb-API, Resource, Posts
+tags: [endpoint]
+summary: "Dieser Endpoint liefert eine Post-Resource."
+sidebar: api_sidebar
+permalink: api_endpoint_posts.html
+folder: api
+---
+
+## Read
+
+### Request
+
+**Beispiel**: Daten zu Post-ID d5a5a2c3-041b-4985-907c-74a2131efc98 anfragen
+
+```
+GET https://api.youthweb.net/posts/d5a5a2c3-041b-4985-907c-74a2131efc98
+Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+Content-Type: application/vnd.api+json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NTgyMzE2MDAsImlzcyI6IkpOdlBnY3ROcEg1Y0s2UmMifQ.BOn0XFDDYa5iBHJb636A0C0m4sU5NO8SA_CPOVHoWNs
+```
+
+### Permissions
+
+- **Allgemein**: Du benötigst in den meisten Fällen ein [Access-Token][api_general_oauth2], um auf diesen Endpoint zugreifen zu können.
+
+### Parameter
+
+Für den Request können keine Parameter angegeben werden.
+
+### Response
+
+```
+Status: 200 OK
+Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+Content-Type: application/vnd.api+json
+
+{
+    "data": {
+        "type": "posts",
+        "id": "d5a5a2c3-041b-4985-907c-74a2131efc98",
+        "attributes": {
+            "title": "The post title",
+            "content": "Lorem ipsum dolor sit amet, sed libris elaboraret eu.",
+            "view_allowed_for": "users",
+            "comments_allowed": true,
+            "comments_count": 15,
+            "created_at": "2016-01-01T21:00:00+01:00",
+            "updated_at": "2016-02-11T17:13:05+01:00",
+        },
+        "relationships": {
+            "author": {},
+            "parent": {}
+        },
+        "links": {
+            "self": "/posts/d5a5a2c3-041b-4985-907c-74a2131efc98"
+        }
+    }
+}
+```
+
+### Felder
+
+| Name                             | Beschreibung                                               | Typ                   |
+|----------------------------------|------------------------------------------------------------|-----------------------|
+| `type`                           | Der Typ der Resource: `posts`                              | `string`              |
+| `id`                             | Die ID der Resource                                        | `string`              |
+| `attributes.title`               | Der Titel des Posts                                        | `string`              |
+| `attributes.content`             | Der Content des Posts                                      | `string`              |
+| `attributes.view_allowed_for`    | Für wen darf dieser Post sichtbar sein?<br />`all`, `users`, `friends` oder `authors`     | `string`   |
+| `attributes.comments_allowed`    | Sind neue Kommentare zu diesem Post erlaubt?               | `boolean`            |
+| `attributes.comments_count`      | Wie viele Kommentare wurden schon verfasst?                | `integer`             |
+| `attributes.created_at`          | Der Erstellzeitpunkt des Posts im Format nach ISO-8601 (`2006-01-01T21:00:00+01:00`)                                                 | `string`              |
+| `attributes.updated_at`          | Der Zeitpunkt der letzten Änderung im Format nach ISO-8601 (`2016-11-14T11:28:47+01:00`)                                                  | `string`              |
+| `relationships.author`           | Ein [Resource Identifier Objekt](http://jsonapi.org/format/1.0/#document-resource-identifier-objects), das auf den Autor verweist | `object`             |
+| `relationships.parent`           | Ein [Resource Identifier Objekt](http://jsonapi.org/format/1.0/#document-resource-identifier-objects), das auf das Elternobjekt des Posts verweist. | `object`             |
+
+## Create
+
+Du kannst mit diesem Endpoint nichts erstellen.
+
+## Delete
+
+Du kannst mit diesem Endpoint nichts löschen.
+
+## Update
+
+Du kannst mit diesem Endpoint nichts ändern.
+
+## Beziehungen
+
+| Beziehung                               | Beschreibung                                                                       |
+|-----------------------------------------|------------------------------------------------------------------------------------|
+| `/posts/{post_id}/author`               | Liefert den Autor als [User][api_endpoint_users]-Resource                          |
+| `/posts/{post_id}/parent`               | Liefert das Elternobjekt, zu dem der Post gehört. Mögliche Resourcen können sein:<br />- [User][api_endpoint_users] |
+| `/posts/{post_id}/relationships/author` | Liefert ein [Resource Identifier Objekt](http://jsonapi.org/format/1.0/#document-resource-identifier-objects) zum Autor  |
+| `/posts/{post_id}/relationships/parent` | Liefert ein [Resource Identifier Objekt](http://jsonapi.org/format/1.0/#document-resource-identifier-objects) zum Elternobjekt  |
+
+{% include links.html %}

--- a/docs/pages/api/api_endpoint_users.md
+++ b/docs/pages/api/api_endpoint_users.md
@@ -101,6 +101,8 @@ Du kannst mit diesem Endpoint nichts ändern.
 
 ## Beziehungen
 
-keine
+| Beziehung                               | Beschreibung                                                                       |
+|-----------------------------------------|------------------------------------------------------------------------------------|
+| `/users/{user_id}/posts`                | Liefert die [Post][api_endpoint_posts]-Resourcen von der Pinnwand eines Users      |
 
 {% include links.html %}

--- a/docs/pages/api/api_general_scopes.md
+++ b/docs/pages/api/api_general_scopes.md
@@ -11,6 +11,7 @@ folder: api
 Bei der [Authorization eines Clients][api_general_oauth2] kann optional der Scope angegeben werden. Die folgenden Scopes können angegeben werden:
 
 - _(kein Scope)_: Zugriff auf alle öffentlichen Daten, die auch jeder andere eingeloggte User sehen darf
+- `post:read`: Erlaubt den Lese-Zugriff auf alle eigenen Pinnwand-Posts und die der Freunde
 - `user:email`: Erlaubt den Lese-Zugriff auf die eigene Email-Adresse
 - `user:read`: Erlaubt den Lese-Zugriff auf die eigenen Profil-Daten, einschließlich der versteckten oder nur für Freunde sichtbaren Daten. Beinhaltet `user:email`.
 

--- a/errors.apib
+++ b/errors.apib
@@ -172,7 +172,7 @@ Hier werden Fehler und Fehlermeldungen der API getestet.
 
     + Body
 
-            {"errors":[{"status":"403","title":"Forbidden","detail":"You have no permission to read this post."}]}
+            {"errors":[{"status":"403","title":"Forbidden"}]}
 
 ## Not existing Posts [/posts/45a5a2c3-041b-4985-907c-74a2131efc98]
 

--- a/errors.apib
+++ b/errors.apib
@@ -152,3 +152,43 @@ Hier werden Fehler und Fehlermeldungen der API getestet.
     + Body
 
             {"errors":[{"status":"401","title":"Unauthorized"}]}
+
+# Group Posts
+
+## Forbidden Posts [/posts/f5a5a2c3-041b-4985-907c-74a2131efc98]
+
+### Request a forbidden post [GET]
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
++ Response 403 (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
+    + Body
+
+            {"errors":[{"status":"403","title":"Forbidden","detail":"You have no permission to read this post."}]}
+
+## Not existing Posts [/posts/45a5a2c3-041b-4985-907c-74a2131efc98]
+
+### Request a not existing post [GET]
++ Request (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
++ Response 404 (application/vnd.api+json)
+
+    + Headers
+
+            Accept: application/vnd.api+json, application/vnd.api+json; net.youthweb.api.version=0.7
+
+    + Body
+
+            {"errors":[{"status":"404","title":"Resource not found"}]}

--- a/features/apiblueprint/posts.feature
+++ b/features/apiblueprint/posts.feature
@@ -21,10 +21,9 @@ Scenario: Requesting a post
 	And the "links" property exists
 	And the "attributes" property exists
 	And scope into the "data.attributes" property
-	And the response contains 8 items
+	And the response contains 7 items
 	And the properties exist:
 		"""
-		uuid
 		title
 		content
 		view_allowed_for

--- a/features/apiblueprint/posts.feature
+++ b/features/apiblueprint/posts.feature
@@ -95,3 +95,52 @@ Scenario: Requesting the author relationship of a post
 		self
 		related
 		"""
+
+Scenario: Requesting the parent of a post
+	Given I have set the "Content-Type" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json; net.youthweb.api.version=0.7"
+	And I have set the "Authorization" header with "Bearer valid_JWT"
+	When I request "GET /posts/d5a5a2c3-041b-4985-907c-74a2131efc98/parent"
+	Then I get a "200" response
+	And the "data" property exists
+	And the "data" property is an object
+	And scope into the "data" property
+	And the response contains 4 items
+	And the "type" property exists
+	And the "type" property is a string equalling "users"
+	And the "id" property exists
+	And the "id" property is a string
+	And the "attributes" property exists
+	And the "attributes" property is an object
+	And the "links" property exists
+	And the "links" property is an object
+	And scope into the "data.links" property
+	And the response contains 1 items
+	And the properties exist:
+		"""
+		self
+		"""
+
+Scenario: Requesting the parent relationship of a post
+	Given I have set the "Content-Type" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json; net.youthweb.api.version=0.7"
+	And I have set the "Authorization" header with "Bearer valid_JWT"
+	When I request "GET /posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/parent"
+	Then I get a "200" response
+	And the "data" property exists
+	And the "data" property is an object
+	And scope into the "data" property
+	And the response contains 2 items
+	And the "type" property exists
+	And the "type" property is a string equalling "users"
+	And the "id" property exists
+	And the "id" property is a string
+	And scope into the "links" property
+	And the response contains 2 items
+	And the properties exist:
+		"""
+		self
+		related
+		"""

--- a/features/apiblueprint/posts.feature
+++ b/features/apiblueprint/posts.feature
@@ -1,0 +1,48 @@
+Feature: Request a post
+	In order to request a post
+	As a user
+
+Scenario: Requesting a post
+	Given I have set the "Content-Type" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json; net.youthweb.api.version=0.7"
+	And I have set the "Authorization" header with "Bearer valid_JWT"
+	When I request "GET /posts/d5a5a2c3-041b-4985-907c-74a2131efc98"
+	Then I get a "200" response
+	And the "included" property exists
+	And the "included" property is an array
+	And the "data" property exists
+	And the "data" property is an object
+	And scope into the "data" property
+	And the response contains 5 items
+	And the "type" property exists
+	And the "type" property is a string equalling "posts"
+	And the "id" property exists
+	And the "links" property exists
+	And the "attributes" property exists
+	And scope into the "data.attributes" property
+	And the response contains 8 items
+	And the properties exist:
+		"""
+		uuid
+		title
+		content
+		view_allowed_for
+		comments_allowed
+		comments_count
+		created_at
+		updated_at
+		"""
+	And scope into the "data.links" property
+	And the response contains 1 items
+	And the properties exist:
+		"""
+		self
+		"""
+	And scope into the "data.relationships" property
+	And the response contains 2 items
+	And the properties exist:
+		"""
+		author
+		parent
+		"""

--- a/features/apiblueprint/posts.feature
+++ b/features/apiblueprint/posts.feature
@@ -38,13 +38,6 @@ Scenario: Requesting a post
 		"""
 		self
 		"""
-	And scope into the "data.relationships" property
-	And the response contains 2 items
-	And the properties exist:
-		"""
-		author
-		parent
-		"""
 
 Scenario: Requesting the author of a post
 	Given I have set the "Content-Type" header with "application/vnd.api+json"

--- a/features/apiblueprint/posts.feature
+++ b/features/apiblueprint/posts.feature
@@ -74,6 +74,8 @@ Scenario: Requesting the author relationship of a post
 	Then I get a "200" response
 	And the "data" property exists
 	And the "data" property is an object
+	And the "links" property exists
+	And the "links" property is an object
 	And scope into the "data" property
 	And the response contains 2 items
 	And the "type" property exists

--- a/features/apiblueprint/posts.feature
+++ b/features/apiblueprint/posts.feature
@@ -1,5 +1,5 @@
-Feature: Request a post
-	In order to request a post
+Feature: Interact with a post
+	In order to request a post or his relationships
 	As a user
 
 Scenario: Requesting a post
@@ -45,4 +45,53 @@ Scenario: Requesting a post
 		"""
 		author
 		parent
+		"""
+
+Scenario: Requesting the author of a post
+	Given I have set the "Content-Type" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json; net.youthweb.api.version=0.7"
+	And I have set the "Authorization" header with "Bearer valid_JWT"
+	When I request "GET /posts/d5a5a2c3-041b-4985-907c-74a2131efc98/author"
+	Then I get a "200" response
+	And the "data" property exists
+	And the "data" property is an object
+	And scope into the "data" property
+	And the response contains 4 items
+	And the "type" property exists
+	And the "type" property is a string equalling "users"
+	And the "id" property exists
+	And the "id" property is a string
+	And the "attributes" property exists
+	And the "attributes" property is an object
+	And the "links" property exists
+	And the "links" property is an object
+	And scope into the "data.links" property
+	And the response contains 1 items
+	And the properties exist:
+		"""
+		self
+		"""
+
+Scenario: Requesting the author relationship of a post
+	Given I have set the "Content-Type" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json; net.youthweb.api.version=0.7"
+	And I have set the "Authorization" header with "Bearer valid_JWT"
+	When I request "GET /posts/d5a5a2c3-041b-4985-907c-74a2131efc98/relationships/author"
+	Then I get a "200" response
+	And the "data" property exists
+	And the "data" property is an object
+	And scope into the "data" property
+	And the response contains 2 items
+	And the "type" property exists
+	And the "type" property is a string equalling "users"
+	And the "id" property exists
+	And the "id" property is a string
+	And scope into the "links" property
+	And the response contains 2 items
+	And the properties exist:
+		"""
+		self
+		related
 		"""

--- a/features/apiblueprint/users.feature
+++ b/features/apiblueprint/users.feature
@@ -1,5 +1,5 @@
-Feature: Request a user
-	In order to request a user
+Feature: Interact with a user
+	In order to request a user or his relationsships
 	As a user
 
 Scenario: Requesting a user
@@ -44,3 +44,26 @@ Scenario: Requesting a user
 		"""
 		self
 		"""
+
+Scenario: Requesting the posts from a users pinnwall
+	Given I have set the "Content-Type" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json; net.youthweb.api.version=0.7"
+	And I have set the "Authorization" header with "Bearer valid_JWT"
+	When I request "GET /users/123456/posts"
+	Then I get a "200" response
+	And the "included" property exists
+	And the "included" property is an array
+	And the "data" property exists
+	And the "data" property is an array
+	And scope into the first "data" property
+	And the response contains 5 items
+	And the "type" property exists
+	And the "type" property is a string equalling "posts"
+	And the "id" property exists
+	And the "attributes" property exists
+	And the "attributes" property is an object
+	And the "relationships" property exists
+	And the "relationships" property is an object
+	And the "links" property exists
+	And the "links" property is an object

--- a/features/errors/posts.feature
+++ b/features/errors/posts.feature
@@ -1,0 +1,39 @@
+Feature: Post Error Tests
+	In order to use the posts endpoint
+	As a visitor
+
+Scenario: Requesting a post without permission
+	Given I have set the "Content-Type" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json; net.youthweb.api.version=0.7"
+	And I have set the "Authorization" header with "Bearer valid_JWT"
+	When I request "GET /posts/f5a5a2c3-041b-4985-907c-74a2131efc98"
+	Then I get a "403" response
+	And the Content-Type Header "application/vnd.api+json" exists
+	And the Accept Header "application/vnd.api+json; net.youthweb.api.version=0.7" exists
+	And the "errors" property exists
+	And the "errors" property is an array
+	And scope into the first "errors" property
+	And the "status" property exists
+	And the "status" property is a string equalling "403"
+	And the "title" property exists
+	And the "title" property is a string equalling "Forbidden"
+	And the "detail" property exists
+	And the "detail" property is a string equalling "You have no permission to read this post."
+
+Scenario: Requesting a not existing post
+	Given I have set the "Content-Type" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json"
+	And I have set the "Accept" header with "application/vnd.api+json; net.youthweb.api.version=0.7"
+	And I have set the "Authorization" header with "Bearer valid_JWT"
+	When I request "GET /posts/45a5a2c3-041b-4985-907c-74a2131efc98"
+	Then I get a "404" response
+	And the Content-Type Header "application/vnd.api+json" exists
+	And the Accept Header "application/vnd.api+json; net.youthweb.api.version=0.7" exists
+	And the "errors" property exists
+	And the "errors" property is an array
+	And scope into the first "errors" property
+	And the "status" property exists
+	And the "status" property is a string equalling "404"
+	And the "title" property exists
+	And the "title" property is a string equalling "Resource not found"

--- a/features/errors/posts.feature
+++ b/features/errors/posts.feature
@@ -18,8 +18,6 @@ Scenario: Requesting a post without permission
 	And the "status" property is a string equalling "403"
 	And the "title" property exists
 	And the "title" property is a string equalling "Forbidden"
-	And the "detail" property exists
-	And the "detail" property is a string equalling "You have no permission to read this post."
 
 Scenario: Requesting a not existing post
 	Given I have set the "Content-Type" header with "application/vnd.api+json"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "server": "drakov -f ./apiary.apib -p 3000",
     "server:errors": "drakov -f ./errors.apib -p 3000",
-    "test": "bash ./vendor/bin/behat --suite=develop",
-    "test:errors": "bash ./vendor/bin/behat --suite=errors",
+    "test": "vendor/bin/behat --suite=develop",
+    "test:errors": "vendor/bin/behat --suite=errors",
     "docs:build": "jekyll build --source docs/ --destination docs/_site",
-    "docs:watch": "jekyll build --watch --source docs/ --destination docs/_site"
+    "docs:watch": "npm run docs:build -- --watch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "server": "drakov -f ./apiary.apib -p 3000",
     "server:errors": "drakov -f ./errors.apib -p 3000",
     "test": "bash ./vendor/bin/behat --suite=develop",
-    "test:errors": "bash ./vendor/bin/behat --suite=errors"
+    "test:errors": "bash ./vendor/bin/behat --suite=errors",
+    "docs:build": "jekyll build --source docs/ --destination docs/_site",
+    "docs:watch": "jekyll build --watch --source docs/ --destination docs/_site"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,5 +3,11 @@
   "version": "0.7.0",
   "devDependencies": {
     "drakov": "^1.0.0"
+  },
+  "scripts": {
+    "server": "drakov -f ./apiary.apib -p 3000",
+    "server:errors": "drakov -f ./errors.apib -p 3000",
+    "test": "bash ./vendor/bin/behat --suite=develop",
+    "test:errors": "bash ./vendor/bin/behat --suite=errors"
   }
 }


### PR DESCRIPTION
**WIP**

Die neue Resource Posts beschreibt einen Pinnwand-Posts und hat zwei Relationships:

1. [x] `parent`: Die Resource, an die der Post geschrieben wurde (z.B. ein User, später auch Group möglich)
2. [x] `author`: Der User, der den Post verfasst hat (eine User-Resource)

Es muss diese neuen Endpoints geben:

1. [x] `GET /posts/<post_id>`: Liefert einen bestimmten Post
2. [x] `GET /users/<user_id>/posts`: Liefert die Posts, die an der Pinnwand eines Users gepostet wurden
3. [x] `GET /posts/<post_id>/author`: Liefert eine User Resource
4. [x] `GET /posts/<post_id>/relationships/author`: Liefert eine Linkage zum Author
5. [x] `GET /posts/<post_id>/parent`: Liefert eine User Resource
6. [x] `GET /posts/<post_id>/relationships/parent`: Liefert eine Linkage zum Elternobjekt

Errors:

1. [x] 404 Error, wenn Post nicht existiert
2. [x] 403 Error, wenn auf Post nicht zugegriffen werden darf

Doku

- [x] Alle Resourcen und Endpoints müssen dokumentiert werden.
- [x] Neuer Scope `post:read` muss dokumentiert werden