### PR TITLE
Add event participant types promised, declined and invited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Deprecated
 
-- attribute `promised_participants_count` in `Event` resources will be removed in a future release, use `promised_participants_count` instead
+- attribute `participants_count` in `Event` resources will be removed in a future release, use `promised_participants_count` instead
 - Version 0.13 and 0.14 are now deprecated and support will be dropped in future. If your apps use this version upgrade them at least to version 0.15.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,7 +226,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Resource `account/stats`
 
-[Unreleased]: https://github.com/youthweb/youthweb-api/compare/0.13...develop
+[Unreleased]: https://github.com/youthweb/youthweb-api/compare/0.14...develop
+[0.14]: https://github.com/youthweb/youthweb-api/compare/0.13...0.14
 [0.13]: https://github.com/youthweb/youthweb-api/compare/0.12...0.13
 [0.12]: https://github.com/youthweb/youthweb-api/compare/0.11...0.12
 [0.11]: https://github.com/youthweb/youthweb-api/compare/0.10...0.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- new attribute `promised_participants_count` in `Event` resources with the number of users promised to come to the event
+- new attribute `declined_participants_count` in `Event` resources with the number of users declined to come to the event
+- new attribute `invited_participants_count` in `Event` resources with the number of users invited to come to the event
+
+### Deprecated
+
+- attribute `promised_participants_count` in `Event` resources will be removed in a future release, use `promised_participants_count` instead
+
 ## [0.13] - 2018-12-16
 
 ### Added

--- a/apiary.apib
+++ b/apiary.apib
@@ -1211,7 +1211,10 @@ Fragt die Userdaten des autorisierten Users ab. Dies ist ein Shortcut für /user
     + `address`: `Musterstraße 42\n12345 Berlin` (string) - Die Adresse, an der das Event stattfindet
     + `comments_allowed`: true (boolean) - Kann dieses Event kommentiert werden?
     + `comments_count`: 7 (number) - Die Gesamtanzahl der Kommentare zu diesem Event
-    + `participants_count`: 15 (number) - Die Gesamtanzahl der User, die Angaben zur Teilnahme an diesem Event gemacht haben
+    + `promised_participants_count`: 15 (number) - Die Anzahl der User, die eine Zustimmung zur Teilnahme an diesem Event gegeben haben
+    + `declined_participants_count`: 2 (number) - Die Anzahl der User, die eine Absage zur Teilnahme an diesem Event gegeben haben
+    + `invited_participants_count`: 3 (number) - Die Anzahl der User, die eingeladen wurden, an diesem Event teilzunehmen
+    + `participants_count`: 15 (number) - (**Veraltet** Verwende stattdessen `promised_participants_count`) Die Anzahl der User, die eine Zustimmung zur Teilnahme an diesem Event gegeben haben
 + `relationships` (object)
     + `author` (object, nullable) - Der Autor des Posts
         + data (User Linkage)

--- a/apiary.apib
+++ b/apiary.apib
@@ -1211,10 +1211,10 @@ Fragt die Userdaten des autorisierten Users ab. Dies ist ein Shortcut für /user
     + `address`: `Musterstraße 42\n12345 Berlin` (string) - Die Adresse, an der das Event stattfindet
     + `comments_allowed`: true (boolean) - Kann dieses Event kommentiert werden?
     + `comments_count`: 7 (number) - Die Gesamtanzahl der Kommentare zu diesem Event
-    + `promised_participants_count`: 15 (number) - Die Anzahl der User, die eine Zustimmung zur Teilnahme an diesem Event gegeben haben
+    + `promised_participants_count`: 10 (number) - Die Anzahl der User, die eine Zustimmung zur Teilnahme an diesem Event gegeben haben
     + `declined_participants_count`: 2 (number) - Die Anzahl der User, die eine Absage zur Teilnahme an diesem Event gegeben haben
-    + `invited_participants_count`: 3 (number) - Die Anzahl der User, die eingeladen wurden, an diesem Event teilzunehmen
-    + `participants_count`: 15 (number) - (**Veraltet** Verwende stattdessen `promised_participants_count`) Die Anzahl der User, die eine Zustimmung zur Teilnahme an diesem Event gegeben haben
+    + `invited_participants_count`: 5 (number) - Die Anzahl der User, die eingeladen wurden, an diesem Event teilzunehmen
+    + `participants_count`: 10 (number) - (**Veraltet** Verwende stattdessen `promised_participants_count`) Die Anzahl der User, die eine Zustimmung zur Teilnahme an diesem Event gegeben haben
 + `relationships` (object)
     + `author` (object, nullable) - Der Autor des Posts
         + data (User Linkage)

--- a/docs/_posts/2019-01-13-Youthweb-API-0.14.md
+++ b/docs/_posts/2019-01-13-Youthweb-API-0.14.md
@@ -1,5 +1,5 @@
 ---
-title:  "Youthweb-API 0.14 erlaubt das Erstellen von Kommentarn zu Posts"
+title:  "Youthweb-API 0.14 erlaubt das Erstellen von Kommentaren zu Posts"
 categories: API
 tags: [api, release]
 summary: "Die neue Version der Youthweb-API erlaubt jetzt das Erstellen von Comments-Resourcen zu Posts-Resource."

--- a/docs/pages/api/api_endpoint_events.md
+++ b/docs/pages/api/api_endpoint_events.md
@@ -55,6 +55,9 @@ Content-Type: application/vnd.api+json
                 "address": "Musterstraße 42\n12345 Berlin",
                 "comments_allowed": true,
                 "comments_count": 15,
+                "promised_participants_count": 10,
+                "declined_participants_count": 2,
+                "invited_participants_count": 5,
                 "participants_count": 10
             },
             "relationships": {
@@ -122,6 +125,9 @@ Content-Type: application/vnd.api+json
             "address": "Musterstraße 42\n12345 Berlin",
             "comments_allowed": true,
             "comments_count": 15,
+            "promised_participants_count": 10,
+            "declined_participants_count": 2,
+            "invited_participants_count": 5,
             "participants_count": 10
         },
         "relationships": {
@@ -155,7 +161,10 @@ Content-Type: application/vnd.api+json
 | `attributes.address`             | Die Adresse, an der das Event stattfinden wird, z.B `Musterstraße 42\n12345 Berlin`. Kann auch leer sein.                                      | `string`              |
 | `attributes.comments_allowed`    | Sind neue Kommentare zu diesem Event erlaubt?                                                                                                  | `boolean`             |
 | `attributes.comments_count`      | Wie viele Kommentare wurden schon verfasst?                                                                                                    | `integer`             |
-| `attributes.participants_count`  | Die Gesamtanzahl der User, die Angaben zur Teilnahme an diesem Event gemacht haben                                                             | `string`              |
+| `attributes.promised_participants_count`  |  Die Anzahl der User, die eine Zustimmung zur Teilnahme an diesem Event gegeben haben                                                             | `string`              |
+| `attributes.declined_participants_count`  | Die Anzahl der User, die eine Absage zur Teilnahme an diesem Event gegeben haben                                                             | `string`              |
+| `attributes.invited_participants_count`  | Die Anzahl der User, die eingeladen wurden, an diesem Event teilzunehmen                                                             | `string`              |
+| `attributes.participants_count`  | (**Veraltet** Verwende stattdessen `promised_participants_count`) Die Anzahl der User, die eine Zustimmung zur Teilnahme an diesem Event gegeben haben                                                             | `string`              |
 | `relationships.author`           | Ein [Resource Identifier Objekt](http://jsonapi.org/format/1.0/#document-resource-identifier-objects), das auf den Autor verweist              | `object`              |
 
 ## Create

--- a/features/core/events.feature
+++ b/features/core/events.feature
@@ -40,7 +40,7 @@ Scenario: Requesting a event
 	And the "links" property exists
 	And the "attributes" property exists
 	And scope into the "data.attributes" property
-	And the response contains 9 items
+	And the response contains 12 items
 	And the properties exist:
 		"""
 		name
@@ -51,6 +51,9 @@ Scenario: Requesting a event
 		address
 		comments_allowed
 		comments_count
+		promised_participants_count
+		declined_participants_count
+		invited_participants_count
 		participants_count
 		"""
 	And scope into the "data.links" property


### PR DESCRIPTION
A user can invite other users to an event. A user could also promise or decline a participation on an event.
The new 3 attributes shows the number of users promises, declined or invited to an event. The attribute `participants_count` will became deprecate and will be replaces with the new attribute `promised_participants_count`.